### PR TITLE
Fixed erroneous target_arch of sqrt function

### DIFF
--- a/crates/geom/src/lib.rs
+++ b/crates/geom/src/lib.rs
@@ -165,7 +165,7 @@ impl Ray {
     }
 }
 
-#[cfg(target_arch="x64_64")]
+#[cfg(target_arch="x86_64")]
 fn sqrt(mut v: f64) -> f64 {
     unsafe {
         core::arch::asm!(


### PR DESCRIPTION
Changed target arch of sqrt function from x64_64 to x86_64